### PR TITLE
Fix URL to Nexus 6P device tree

### DIFF
--- a/_devices/huaweinexus6p.markdown
+++ b/_devices/huaweinexus6p.markdown
@@ -6,7 +6,7 @@ downloadfolder: angler
 supportstatus: Current
 maintainer: Dees_Troy
 oem: Huawei
-devicetree: https://github.com/TeamWin/android_device_lge_angler
+devicetree: https://github.com/TeamWin/android_device_huawei_angler
 ---
 
 {% include disclaimer.html %}


### PR DESCRIPTION
Nexus 6P is made by Huawei, not LG