### PR TITLE
Correcting xiaomipocophonef1.markdown

### DIFF
--- a/_xiaomi/xiaomipocophonef1.markdown
+++ b/_xiaomi/xiaomipocophonef1.markdown
@@ -3,8 +3,8 @@ layout: device
 title:  "Xiaomi Pocophone F1"
 codename: beryllium
 downloadfolder: beryllium
-supportstatus: Current
-maintainer: Dees_Troy
+supportstatus: Not Supported
+maintainer: none
 oem: Xiaomi
 devicetree: "https://github.com/TeamWin/android_device_xiaomi_beryllium"
 ---


### PR DESCRIPTION
For clarity and transparency, and since it is observed that there have been no developments to the Beryllium TWRP past January 2019, I request the following corrections.