### PR TITLE
Korean S7/S7 edge models to use International TWRP

### DIFF
--- a/_samsung/samsunggalaxys7.markdown
+++ b/_samsung/samsunggalaxys7.markdown
@@ -21,21 +21,11 @@ ddof: "/dev/block/platform/155a0000.ufs/by-name/RECOVERY"
 
 <div class='page-heading'>Download Links:</div>
 <hr />
-<p class="text">International &amp; Canada (SM-G930F, SM-G930FD, SM-G930X, SM-G930W8):</p>
+<p class="text">International &amp; Canada (SM-G930F, SM-G930FD, SM-G930X, SM-G930W8) &amp; Korea (SM-G930K, SM-G930L, SM-G930S):</p>
 <ul>
 {% for mirror in site.data.mirrors %}
   <li>
     <a href="{{ mirror.baseurl }}herolte">
-      {{ mirror.description }}
-    </a>
-  </li>
-{% endfor %}
-</ul>
-<p class="text">Korea (SM-G930K, SM-G930L, SM-G930S):</p>
-<ul>
-{% for mirror in site.data.mirrors %}
-  <li>
-    <a href="{{ mirror.baseurl }}heroltekor">
       {{ mirror.description }}
     </a>
   </li>

--- a/_samsung/samsunggalaxys7edge.markdown
+++ b/_samsung/samsunggalaxys7edge.markdown
@@ -21,21 +21,11 @@ ddof: "/dev/block/platform/155a0000.ufs/by-name/RECOVERY"
 
 <div class='page-heading'>Download Links:</div>
 <hr />
-<p class="text">International &amp; Canada (SM-G935F, SM-G935FD, SM-G935X, SM-G935W8):</p>
+<p class="text">International &amp; Canada (SM-G935F, SM-G935FD, SM-G935X, SM-G935W8) &amp; Korea (SM-G935K, SM-G935L, SM-G935S):</p>
 <ul>
 {% for mirror in site.data.mirrors %}
   <li>
     <a href="{{ mirror.baseurl }}hero2lte">
-      {{ mirror.description }}
-    </a>
-  </li>
-{% endfor %}
-</ul>
-<p class="text">Korea (SM-G935K, SM-G935L, SM-G935S):</p>
-<ul>
-{% for mirror in site.data.mirrors %}
-  <li>
-    <a href="{{ mirror.baseurl }}hero2ltekor">
       {{ mirror.description }}
     </a>
   </li>


### PR DESCRIPTION
Korean variants are deprecated and international variant supports the Korean models.