### PR TITLE
typo - update lggwatchr

### DIFF
--- a/_lg/lggwatchr.markdown
+++ b/_lg/lggwatchr.markdown
@@ -1,6 +1,6 @@
 ---
 layout: device
-title:  "LG G Watch"
+title:  "LG G Watch R"
 codename: lenok
 downloadfolder: lenok
 oldurl: http://teamw.in/project/twrp2/281


### PR DESCRIPTION
missing `R` in title
the right device name is `LG G Watch R`